### PR TITLE
add bool generator

### DIFF
--- a/examples/cli.roc
+++ b/examples/cli.roc
@@ -1,6 +1,6 @@
 app "rand"
     packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br", rand: "../package/main.roc" }
-    imports [pf.Stdout, pf.Task.{ Task }, rand.Generator, rand.XorShift32]
+    imports [pf.Stdout, pf.Task.{ Task }, rand.Generator, rand.XorShift32, rand.RngCore]
     provides [main] to pf
 
 main : Task {} I32
@@ -15,4 +15,5 @@ main =
 gen =
     x <- XorShift32.u64 |> Generator.andThen
     y <- XorShift32.u64 |> Generator.andThen
-    { x, y } |> Generator.return
+    z <- RngCore.bool |> Generator.andThen
+    { x, y, z } |> Generator.return

--- a/package/RngCore.roc
+++ b/package/RngCore.roc
@@ -3,11 +3,20 @@ interface RngCore exposes [
         seed,
         u32,
         u64,
+        bool,
     ] imports [
-        Generator.{ Generator },
+        Generator.{ Generator, andThen, return },
     ]
 
 RngCore implements
     seed : input -> rng where rng implements RngCore
     u32 : Generator rng U32 where rng implements RngCore
     u64 : Generator rng U64 where rng implements RngCore
+
+bool : Generator rng Bool where rng implements RngCore
+bool =
+    x <- u32 |> andThen
+    x
+    |> Num.shiftRightBy 31
+    |> Bool.isEq 0
+    |> return


### PR DESCRIPTION
`RUST_BACKTRACE=1 roc run examples/cli.roc`

```
An internal compiler expectation was broken.
This is definitely a compiler bug.
Please file an issue here: https://github.com/roc-lang/roc/issues/new/choose
thread '<unnamed>' panicked at 'no lambda set found for (`21.IdentId(2)`, []): LambdaSet {
    set: [
        ( 21.7, []),
    ],
    args: [
        InLayout(U32),
    ],
    ret: InLayout(
        39,
    ),
    representation: InLayout(
        40,
    ),
    full_layout: InLayout(
        41,
    ),
}', crates/compiler/mono/src/layout.rs:1597:17
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/core/src/panicking.rs:67:14
   2: roc_mono::layout::LambdaSet::find_lambda_name
   3: roc_mono::ir::find_lambda_name
   4: roc_mono::ir::specialize_symbol
   5: roc_mono::ir::assign_to_symbol
   6: roc_mono::ir::assign_to_symbols
   7: roc_mono::ir::call_by_name
   8: roc_mono::ir::with_hole
   9: roc_mono::ir::from_can
  10: roc_mono::ir::specialize_variable
  11: roc_mono::ir::specialize_external_help
  12: roc_mono::ir::specialize_all
  13: roc_load_internal::file::run_task
  14: core::ops::function::FnOnce::call_once{{vtable.shim}}
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```