### PR TITLE
separate generic code

### DIFF
--- a/package/Impls.roc
+++ b/package/Impls.roc
@@ -1,0 +1,16 @@
+interface Impls exposes [
+        u64viau32,
+    ] imports [
+        Generator.{ Generator, andThen, return },
+        RngCore.{ u32 },
+    ]
+
+u64viau32 =
+    x <- u32 |> andThen
+    y <- u32 |> andThen
+
+    (Num.toU64 x)
+    |> Num.shiftLeftBy 32
+    |> Num.bitwiseOr (Num.toU64 y)
+    |> return
+

--- a/package/XorShift32.roc
+++ b/package/XorShift32.roc
@@ -4,8 +4,9 @@ interface XorShift32 exposes [
         u32,
         seed,
     ] imports [
-        Generator.{ embed, Generator, andThen, return },
+        Generator.{ embed, Generator },
         RngCore.{ RngCore },
+        Impls.{ u64viau32 },
     ]
 
 XorShift32 := U32
@@ -27,11 +28,4 @@ u32 = embed \@XorShift32 state ->
     |> \s -> Num.bitwiseXor s (Num.shiftLeftBy s 5)
     |> \s -> (@XorShift32 s, s)
 
-u64 =
-    x <- u32 |> andThen
-    y <- u32 |> andThen
-
-    (Num.toU64 x)
-    |> Num.shiftLeftBy 32
-    |> Num.bitwiseOr (Num.toU64 y)
-    |> return
+u64 = u64viau32


### PR DESCRIPTION
`roc check package/XorShift32.roc`

```
── TYPE MISMATCH in package/XorShift32.roc ─────────────────────────────────────

This specialization of u64 is overly general:

31│  u64 = u64viau32
     ^^^

This value is a declared specialization of type:

    Generator state (Int Unsigned64) where state implements RngCore.RngCore

But the type annotation on u64 says it must match:

    Generator rng U64 where rng implements RngCore.RngCore

Note: The specialized type is too general, and does not provide a
concrete type where a type variable is bound to an ability.

Specializations can only be made for concrete types. If you have a
generic implementation for this value, perhaps you don't need an
ability?

────────────────────────────────────────────────────────────────────────────────

1 error and 0 warnings found in 38 ms.
```