### PR TITLE
annotation bug demo

### DIFF
--- a/examples/cli.roc
+++ b/examples/cli.roc
@@ -1,6 +1,6 @@
 app "rand"
     packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br", rand: "../package/main.roc" }
-    imports [pf.Stdout, pf.Task.{ Task }, rand.Generator, rand.XorShift32]
+    imports [pf.Stdout, pf.Task.{ Task }, rand.Generator, rand.XorShift32, rand.RngCore]
     provides [main] to pf
 
 main : Task {} I32
@@ -15,4 +15,13 @@ main =
 gen =
     x <- XorShift32.u64 |> Generator.andThen
     y <- XorShift32.u64 |> Generator.andThen
-    { x, y } |> Generator.return
+    z <- bool |> Generator.andThen
+    { x, y, z } |> Generator.return
+
+bool : Generator.Generator rng Bool where rng implements RngCore.RngCore
+bool =
+    x <- RngCore.u32 |> Generator.andThen
+    x
+    |> Num.shiftRightBy 31
+    |> Bool.isEq 0
+    |> Generator.return


### PR DESCRIPTION
`roc check examples/cli.roc`

```
── TYPE MISMATCH in examples/cli.roc ───────────────────────────────────────────

This 2nd argument to |> has an unexpected type:

17│>      y <- XorShift32.u64 |> Generator.andThen
18│>      z <- bool |> Generator.andThen
19│>      { x, y, z } |> Generator.return

The argument is an anonymous function of type:

    U64 -> Generator rng { … } where rng implements RngCore.RngCore

But |> needs its 2nd argument to be:

    U64 -> Generator XorShift32.XorShift32 { … }

Note: The type variable rng says it can take on any value that
implements the ability RngCore.

But, I see that the type is only ever used as a a XorShift32 value.
Can you replace rng with a more specific type?

────────────────────────────────────────────────────────────────────────────────

1 error and 0 warnings found in 39 ms.
```